### PR TITLE
Replace fatalError in Bundle.module with recoverable fallback

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,7 @@ let package = Package(
         .target(
             name: "SwiftIP2ASN",
             resources: [
-                // Place the shipping database at Sources/SwiftIP2ASN/Resources/ip2asn.ultra
-                .process("Resources")
+                .process("Resources/ip2asn.ultra")
             ]
         ),
         .target(

--- a/Sources/SwiftIP2ASN/BundleAccessor.swift
+++ b/Sources/SwiftIP2ASN/BundleAccessor.swift
@@ -20,6 +20,7 @@ extension Foundation.Bundle {
     public static var safeModule: Bundle? {
         let bundleName = "SwiftIP2ASN_SwiftIP2ASN"
 
+        // Standard SPM candidate paths
         let candidates = [
             Bundle.main.resourceURL,
             Bundle(for: BundleFinder.self).resourceURL,
@@ -31,6 +32,9 @@ extension Foundation.Bundle {
             Bundle(for: BundleFinder.self).resourceURL?
                 .deletingLastPathComponent()
                 .deletingLastPathComponent(),
+            // Additional paths for non-standard layouts (.pkg installs, Sparkle updates)
+            Bundle.main.privateFrameworksURL,
+            Bundle.main.sharedFrameworksURL,
         ]
 
         for candidate in candidates {
@@ -38,6 +42,12 @@ extension Foundation.Bundle {
             if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
                 return bundle
             }
+        }
+
+        // Last resort: ask the main bundle directly (handles nested/relocated bundles)
+        if let url = Bundle.main.url(forResource: bundleName, withExtension: "bundle"),
+           let bundle = Bundle(url: url) {
+            return bundle
         }
 
         return nil

--- a/Sources/SwiftIP2ASN/BundleAccessor.swift
+++ b/Sources/SwiftIP2ASN/BundleAccessor.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Safe alternative to SwiftPM's auto-generated `Bundle.module` accessor.
+///
+/// The auto-generated `resource_bundle_accessor.swift` calls `fatalError()` when the
+/// resource bundle `SwiftIP2ASN_SwiftIP2ASN` can't be found at runtime — an unrecoverable
+/// crash with no opportunity to handle it. This property performs the same candidate-path
+/// search but returns `nil` instead of trapping, allowing callers to throw a recoverable
+/// error (`.resourceNotFound`).
+///
+/// See: https://github.com/Network-Weather/Swift-IP2ASN/issues/1
+
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Returns the SwiftIP2ASN resource bundle, or `nil` if it can't be located.
+    ///
+    /// This searches the same candidate paths as SPM's generated `Bundle.module`
+    /// but avoids the `fatalError` when none match.
+    public static var safeModule: Bundle? {
+        let bundleName = "SwiftIP2ASN_SwiftIP2ASN"
+
+        let candidates = [
+            Bundle.main.resourceURL,
+            Bundle(for: BundleFinder.self).resourceURL,
+            Bundle.main.bundleURL,
+            Bundle(for: BundleFinder.self).resourceURL?
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent(),
+            Bundle(for: BundleFinder.self).resourceURL?
+                .deletingLastPathComponent()
+                .deletingLastPathComponent(),
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SwiftIP2ASN/EmbeddedDatabase.swift
+++ b/Sources/SwiftIP2ASN/EmbeddedDatabase.swift
@@ -55,6 +55,7 @@ public enum EmbeddedDatabase {
     /// The database file is located at `Sources/SwiftIP2ASN/Resources/ip2asn.ultra`
     /// and is included automatically when you add SwiftIP2ASN as a dependency.
     ///
+    /// - Parameter bundle: The bundle to load the resource from. Defaults to `.module`.
     /// - Returns: An ``UltraCompactDatabase`` ready for IP lookups.
     /// - Throws: ``Error/resourceNotFound`` if the database file is missing.
     ///
@@ -65,8 +66,8 @@ public enum EmbeddedDatabase {
     /// print("Loaded \(db.entryCount) IP ranges")
     /// print("Covering \(db.uniqueASNCount) unique ASNs")
     /// ```
-    public static func loadUltraCompact() throws -> UltraCompactDatabase {
-        guard let url = Bundle.module.url(forResource: "ip2asn", withExtension: "ultra") else {
+    public static func loadUltraCompact(from bundle: Bundle? = .safeModule) throws -> UltraCompactDatabase {
+        guard let url = bundle?.url(forResource: "ip2asn", withExtension: "ultra") else {
             throw Error.resourceNotFound
         }
         return try UltraCompactDatabase(path: url.path)

--- a/Tests/SwiftIP2ASNTests/EmbeddedDatabaseTests.swift
+++ b/Tests/SwiftIP2ASNTests/EmbeddedDatabaseTests.swift
@@ -18,14 +18,36 @@ final class EmbeddedDatabaseTests: XCTestCase {
         }
     }
 
-    func testEmbeddedUltraLookups() throws {
-        // Try to load the embedded Ultra DB; skip if not present
-        let db: UltraCompactDatabase
-        do {
-            db = try EmbeddedDatabase.loadUltraCompact()
-        } catch {
-            throw XCTSkip("Embedded ip2asn.ultra not present; skipping embedded DB checks")
+    /// Packaging integrity check: verifies the resource bundle and database are
+    /// present, loadable, and contain a reasonable number of entries.
+    /// This test hard-fails (not XCTSkip) because a missing database means a
+    /// broken release that will crash or degrade at runtime.
+    func testEmbeddedDatabasePackagingIntegrity() throws {
+        // 1. safeModule must find the resource bundle
+        let bundle = Bundle.safeModule
+        XCTAssertNotNil(bundle, "Bundle.safeModule should locate SwiftIP2ASN_SwiftIP2ASN.bundle")
+
+        // 2. The .ultra resource must exist inside it
+        let url = bundle?.url(forResource: "ip2asn", withExtension: "ultra")
+        XCTAssertNotNil(url, "ip2asn.ultra must be present in the resource bundle")
+
+        // 3. File should be non-trivial (current DB is ~3.4 MB)
+        if let path = url?.path {
+            let attrs = try FileManager.default.attributesOfItem(atPath: path)
+            let size = attrs[.size] as? UInt64 ?? 0
+            XCTAssertGreaterThan(size, 1_000_000, "ip2asn.ultra should be >1 MB (got \(size) bytes)")
         }
+
+        // 4. Database must load and contain substantial data
+        let db = try EmbeddedDatabase.loadUltraCompact()
+        XCTAssertGreaterThan(db.entryCount, 100_000,
+            "Embedded DB should have >100k entries (got \(db.entryCount))")
+        XCTAssertGreaterThan(db.uniqueASNCount, 10_000,
+            "Embedded DB should have >10k unique ASNs (got \(db.uniqueASNCount))")
+    }
+
+    func testEmbeddedUltraLookups() throws {
+        let db = try EmbeddedDatabase.loadUltraCompact()
 
         // Canonical IPs that should be present in a current full DB
         let cases: [(String, UInt32)] = [

--- a/Tests/SwiftIP2ASNTests/EmbeddedDatabaseTests.swift
+++ b/Tests/SwiftIP2ASNTests/EmbeddedDatabaseTests.swift
@@ -3,6 +3,21 @@ import XCTest
 @testable import SwiftIP2ASN
 
 final class EmbeddedDatabaseTests: XCTestCase {
+
+    /// Verifies that loadUltraCompact() throws .resourceNotFound (not fatalError)
+    /// when the resource bundle doesn't contain ip2asn.ultra.
+    /// Regression test for https://github.com/Network-Weather/Swift-IP2ASN/issues/1
+    func testLoadUltraCompactThrowsResourceNotFoundForMissingBundle() throws {
+        // Use the test target's bundle, which doesn't contain ip2asn.ultra
+        let emptyBundle = Bundle(for: type(of: self))
+        XCTAssertThrowsError(try EmbeddedDatabase.loadUltraCompact(from: emptyBundle)) { error in
+            guard case EmbeddedDatabase.Error.resourceNotFound = error else {
+                XCTFail("Expected .resourceNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
     func testEmbeddedUltraLookups() throws {
         // Try to load the embedded Ultra DB; skip if not present
         let db: UltraCompactDatabase


### PR DESCRIPTION
## Summary

- Add `Bundle.safeModule` (returns `Bundle?`) that mirrors SPM's auto-generated `Bundle.module` candidate-path search but returns `nil` instead of calling `fatalError()` when the resource bundle can't be found
- Update `EmbeddedDatabase.loadUltraCompact()` to use `safeModule`, so a missing bundle throws `.resourceNotFound` instead of crashing
- Add test verifying the `.resourceNotFound` error path

## Context

SPM's auto-generated `resource_bundle_accessor.swift` calls `fatalError("could not load resource bundle")` when the `SwiftIP2ASN_SwiftIP2ASN.bundle` directory isn't found at runtime. This caused a fatal crash on macOS Tahoe beta ([APPLE-MACOS-4D](https://network-weather.sentry.io/issues/APPLE-MACOS-4D)). The `loadUltraCompact()` method was designed to throw `.resourceNotFound`, but `Bundle.module` traps before it gets the chance.

Since SPM still generates the accessor even when a custom `Bundle.module` is present (causing duplicate symbol errors), we provide `Bundle.safeModule: Bundle?` as an alternative that callers use instead.

Fixes #1

## Test plan

- [x] `testLoadUltraCompactThrowsResourceNotFoundForMissingBundle` — passes an empty bundle, verifies `.resourceNotFound` is thrown (not `fatalError`)
- [x] `testEmbeddedUltraLookups` — confirms normal bundle lookup still works
- [x] `swift build` clean
- [ ] Verify in a host app with packaging edge cases (macOS Tahoe beta, non-standard bundle layouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)