### PR TITLE
Run full test suite in auto-update workflow

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run tests
         if: steps.diff.outputs.changed == 'true'
-        run: swift test --filter EmbeddedDatabaseTests
+        run: swift test
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Auto-update PRs (e.g. #4) get no CI runs because workflows don't fire on PRs created with the default `GITHUB_TOKEN` (GitHub's anti-recursion safety).
- That makes the `Run tests` step inside `update-database.yml` the only gate before we ship a new embedded `.ultra` blob — but it was filtered to just `EmbeddedDatabaseTests`.
- Drop the filter so the full suite runs before the bot opens/updates the PR.

## Test plan
- [ ] Merge, then manually trigger the workflow via `workflow_dispatch` to confirm full `swift test` still passes against the latest TSV.