### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -57,5 +57,5 @@ jobs:
             - Previous size: ${{ steps.diff.outputs.old_size }} bytes
             - New size: ${{ steps.diff.outputs.new_size }} bytes
 
-            All `EmbeddedDatabaseTests` pass with the new database.
+            Full `swift test` suite passes with the new database.
           delete-branch: true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Network-Weather/swift-ip2asn", from: "0.3.0")
+    .package(url: "https://github.com/Network-Weather/swift-ip2asn", from: "0.3.1")
 ]
 ```
 


### PR DESCRIPTION
## Summary
- Fix stale "All `EmbeddedDatabaseTests` pass" string in `update-database.yml` PR body template; it now reflects the full `swift test` gate added in #5.
- Bump README SPM example to `0.3.1`.

## Test plan
- [ ] CI passes
- [ ] Tag `v0.3.1` and publish release after merge